### PR TITLE
Env variable for api phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm run dev
 Also you can develop only the client application without cloning server repository `eodiro-api2`.
 
 ```zsh
-npm run dev --useProdApi
+npm run dev --use-prod-api
 ```
 
 > Recent client application in the master branch may not match to the API distributed on https://eodiro.com. To develop using the recent APIs, download and run API repository locally.
@@ -49,10 +49,10 @@ npm run dev --useProdApi
 By default, `npm run dev` connects to local dev API server and `npm start` tries to connect to the real server(https://eodiro.com). However, sometimes you need to test the production-ready, built version of client application with the dev API. To achieve this, simply pass an argument similar to the one above
 
 ```zsh
-npm start --useDevApi
+npm start --use-dev-api
 ```
 
-> `--useProdApi` and `--useDevApi` are only for the purpose of tests. Do not use them in production. For more information about API hosts, checkout the [source code](https://github.com/payw-org/eodiro/blob/master/src/modules/api-host.ts).
+> `--use-prod-api` and `--use-dev-api` are only for the purpose of tests. Do not use them in production. For more information about API hosts, checkout the [source code](https://github.com/payw-org/eodiro/blob/master/src/modules/api-host.ts).
 
 ## 🧑‍💻 Developers Guide
 

--- a/src/modules/api-host.ts
+++ b/src/modules/api-host.ts
@@ -1,8 +1,8 @@
 /**
- * Pass --useProdApi to use stable production API version
+ * Pass --use-prod-api to use stable production API version
  * published on the server
  *
- * Pass --useDevApi to use dev version of API
+ * Pass --use-dev-api to use dev version of API
  * It requires local API server running
  *
  * Use these arguments only for the purpose of tests

--- a/src/modules/api-host.ts
+++ b/src/modules/api-host.ts
@@ -39,7 +39,7 @@ export default class ApiHost {
     // Forced to use production API
     // distributed on eodiro.com server
     if (
-      process.env.npm_config_useProdApi ||
+      process.env.npm_config_use_prod_api ||
       (isClient() && document.documentElement.hasAttribute('data-use-prod-api'))
     ) {
       return this.setHost(`https://${sub}.eodiro.com`, cdn)
@@ -47,7 +47,7 @@ export default class ApiHost {
 
     // Forced to use dev API
     if (
-      process.env.npm_config_useDevApi ||
+      process.env.npm_config_use_dev_api ||
       (isClient() && document.documentElement.hasAttribute('data-use-dev-api'))
     ) {
       if (isClient()) {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -8,8 +8,8 @@ class MyDocument extends Document {
 
   render() {
     const devOptions = {}
-    const useProdApi = process.env.npm_config_useProdApi === 'true'
-    const useDevApi = process.env.npm_config_useDevApi === 'true'
+    const useProdApi = process.env.npm_config_use_prod_api === 'true'
+    const useDevApi = process.env.npm_config_use_dev_api === 'true'
 
     if (useProdApi || useDevApi) {
       devOptions['data-forced-api-enabled'] = ''


### PR DESCRIPTION
 - npm config env variable is not worked so far. It is forced to be written with underscore and lower case alphabet because it is used for env constant. [Reference](https://docs.npmjs.com/misc/config)